### PR TITLE
Allow for directives with all whitespace value

### DIFF
--- a/lib/chordpro/html.rb
+++ b/lib/chordpro/html.rb
@@ -18,7 +18,9 @@ module Chordpro
     alias_method :t, :title
 
     def subtitle(subtitle)
-      @html.h2(class: "subtitle") { |h2| h2.text! subtitle }
+      unless subtitle.match(/^\s*$/)
+        @html.h2(class: "subtitle") { |h2| h2.text! subtitle }
+      end
     end
     alias_method :st, :subtitle
     alias_method :su, :subtitle

--- a/lib/chordpro/transform.rb
+++ b/lib/chordpro/transform.rb
@@ -5,6 +5,11 @@ module Chordpro
       Chordpro::Directive.new(directive_name, value.to_s)
     end
 
+    rule(directive: {name: simple(:name), value: []}) do
+      directive_name = Directive.find(name) || Directive::Name.new(name.to_s)
+      Chordpro::Directive.new(directive_name, "")
+    end
+
     rule(directive: {name: simple(:name)}) do
       directive_name = Directive.find(name) || Directive::Name.new(name.to_s)
       Chordpro::Directive.new(directive_name)

--- a/spec/chordpro/html_spec.rb
+++ b/spec/chordpro/html_spec.rb
@@ -19,6 +19,9 @@ describe Chordpro::HTML do
     it "renders h2 for #{name}" do
       expect(html("{#{name}:The Beatles}").to_s).to eq('<h2 class="subtitle">The Beatles</h2>')
     end
+    it "allows empty #{name}" do
+      expect(html("{#{name}: }").to_s).to eq('')
+    end
   end
 
   it "guards against xss in the subtitle" do


### PR DESCRIPTION
A directive with an empty (all whitespace) value like
```
{subtitle: }
```
will now result in a subtitle with value "". This is done in order to
make the parsing more robust.